### PR TITLE
Get rid of camera lock on flag holder (optional)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vs/
+Release
+Debug

--- a/Project1.vcxproj
+++ b/Project1.vcxproj
@@ -14,18 +14,19 @@
     <ProjectGuid>{3D307284-00E4-4499-9B16-206D5891AAA6}</ProjectGuid>
     <RootNamespace>Project1</RootNamespace>
     <ProjectName>Frozlunky</ProjectName>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v110_xp</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
@@ -45,10 +46,11 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_WINSOCKAPI_=;WIN32;_CRT_SECURE_NO_WARNINGS;DEBUG_MODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>pugixml.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;Wldap32.lib;fltkd.lib;psapi.lib;muparser.lib;Winmm.lib;enet.lib;pugixml_d.lib;libcurl-d.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -66,13 +68,14 @@
       <AdditionalOptions>-DPSAPI_VERSION=1 -DCURL_STATICLIB=1 -DWIN32=1 -D_CRT_SECURE_NO_WARNINGS=1 %(AdditionalOptions)</AdditionalOptions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WholeProgramOptimization>true</WholeProgramOptimization>
+      <PreprocessorDefinitions>_WINSOCKAPI_=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>ws2_32.lib;Wldap32.lib;fltk.lib;psapi.lib;muparser32.lib;libeay32MD.lib;Winmm.lib;enet.lib;pugixml.lib;libcurl_a.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>ws2_32.lib;Wldap32.lib;fltk.lib;psapi.lib;muparser.lib;Winmm.lib;enet.lib;pugixml.lib;libcurl.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Windows</SubSystem>
       <AssemblyDebug>false</AssemblyDebug>
     </Link>
   </ItemDefinitionGroup>
@@ -252,12 +255,6 @@
     <ClInclude Include="watermark.h" />
     <ClInclude Include="winheaders.h" />
     <ClInclude Include="yeti_remove_patch.h" />
-  </ItemGroup>
-  <ItemGroup>
-    <Image Include="..\fr.ico" />
-  </ItemGroup>
-  <ItemGroup>
-    <ResourceCompile Include="..\resources.rc" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Project1.vcxproj
+++ b/Project1.vcxproj
@@ -123,6 +123,7 @@
     <ClCompile Include="new_game_detector.cpp" />
     <ClCompile Include="offline.cpp" />
     <ClCompile Include="oneplayer_only.cpp" />
+    <ClCompile Include="own_camera_patch.cpp" />
     <ClCompile Include="patch_group.cpp" />
     <ClCompile Include="precise_patch.cpp" />
     <ClCompile Include="preconditions.cpp" />
@@ -178,6 +179,7 @@
     <ClInclude Include="level_settings_gui.h" />
     <ClInclude Include="message_displayer.h" />
     <ClInclude Include="message_grid.h" />
+    <ClInclude Include="own_camera_patch.h" />
     <ClInclude Include="protect_achiev.h" />
     <ClInclude Include="remove_ghost_patch.h" />
     <ClInclude Include="resource_editor.h" />

--- a/Project1.vcxproj.filters
+++ b/Project1.vcxproj.filters
@@ -299,6 +299,9 @@
     <ClCompile Include="message_grid.cpp">
       <Filter>Source Files\special\tile_editing</Filter>
     </ClCompile>
+    <ClCompile Include="own_camera_patch.cpp">
+      <Filter>Source Files\netplay</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="append_ai.h">
@@ -582,6 +585,9 @@
     </ClInclude>
     <ClInclude Include="message_grid.h">
       <Filter>Header Files\special\tile_editing</Filter>
+    </ClInclude>
+    <ClInclude Include="own_camera_patch.h">
+      <Filter>Header Files\netplay</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Project1.vcxproj.filters
+++ b/Project1.vcxproj.filters
@@ -9,10 +9,6 @@
       <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
       <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
     </Filter>
-    <Filter Include="Resource Files">
-      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
-      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
-    </Filter>
     <Filter Include="Header Files\special">
       <UniqueIdentifier>{fec5f823-818f-4b1a-b25b-8ffd70bb5cd2}</UniqueIdentifier>
     </Filter>
@@ -587,15 +583,5 @@
     <ClInclude Include="message_grid.h">
       <Filter>Header Files\special\tile_editing</Filter>
     </ClInclude>
-  </ItemGroup>
-  <ItemGroup>
-    <Image Include="..\fr.ico">
-      <Filter>Resource Files</Filter>
-    </Image>
-  </ItemGroup>
-  <ItemGroup>
-    <ResourceCompile Include="..\resources.rc">
-      <Filter>Resource Files</Filter>
-    </ResourceCompile>
   </ItemGroup>
 </Project>

--- a/debug.h
+++ b/debug.h
@@ -1,7 +1,5 @@
 #pragma once
 
-//#define DEBUG_MODE
-
 #ifdef DEBUG_MODE
 #define DBG_EXPR(expr) expr
 #else

--- a/frozboards/request.cpp
+++ b/frozboards/request.cpp
@@ -1,4 +1,5 @@
 #include "../debug.h"
+#include "../winheaders.h"
 #include "request.h"
 
 #include <curl/curl.h>

--- a/frozboards/session.cpp
+++ b/frozboards/session.cpp
@@ -9,7 +9,7 @@
 
 #include <mutex>
 #include <curl/curl.h>
-#include <muparser/muParser.h>
+#include <muParser.h>
 #include <boost/assign.hpp>
 
 #define FROZ_AUTH_UI_URL "http://frozboards.sashavol.com/verify.htm?a="

--- a/game_hooks.cpp
+++ b/game_hooks.cpp
@@ -211,7 +211,7 @@ bool valid_steamid(char id[STEAMID_MEM_LENGTH]) {
 		}
 	}
 
-	id[STEAMID_MEM_LENGTH] = 0x0;
+	id[STEAMID_MEM_LENGTH - 1] = 0x0;
 	return true;
 }
 

--- a/gui.cpp
+++ b/gui.cpp
@@ -212,7 +212,7 @@ void undo_patches() {
 }
 
 bool active_daily() {
-	return daily;
+	return daily != nullptr;
 }
 
 void hide_gui(Fl_Widget* ignored = nullptr) {

--- a/netplay_connection.cpp
+++ b/netplay_connection.cpp
@@ -38,12 +38,10 @@ NetplayPacket::NetplayPacket(void* data, size_t len) : data(data), len(len) {
 NetplayPacket::~NetplayPacket() {
 	if(_packet) {
 		enet_packet_destroy(_packet);
-	}
-
-	if(data) {
-		delete[] data;
-		data = nullptr;
-	}
+    } else if (data) {
+        delete[] data;
+        data = nullptr;
+    }
 }
 
 ///////////////////////////

--- a/netplay_session.cpp
+++ b/netplay_session.cpp
@@ -132,9 +132,11 @@ NetplaySession::NetplaySession(int pid, std::shared_ptr<InputPushBuilder> pb_net
 	create_worker_thread();
 
 	controller = std::make_shared<NetplaySession_Controller>();
-	antipause = std::make_shared<AntipausePatch>(gh->spel);
+    antipause = std::make_shared<AntipausePatch>(gh->spel);
+    own_camera = std::make_shared<OwnCameraPatch>(pid, gh->spel);
 
 	antipause->perform();
+	own_camera->perform();
 
 	conn->on_disconnect([=](NetplayDisconnectEvent) {
 		close(NS_LOST_CONNECTION);
@@ -368,6 +370,7 @@ void NetplaySession::close(NetplaySessionCloseEvent evt)
 		ipb_net->undo();
 		ipb_local->undo();
 		antipause->undo();
+		own_camera->undo();
 		controller->shutdown = true;
 		aig.reset();
 		irp->undo();

--- a/netplay_session.cpp
+++ b/netplay_session.cpp
@@ -95,7 +95,8 @@ NetplaySession::NetplaySession(int pid, std::shared_ptr<InputPushBuilder> pb_net
 										std::shared_ptr<InputReceivePatch> i,
 										std::shared_ptr<Seeder> s, 
 										std::shared_ptr<GameHooks> g,
-										std::shared_ptr<DerandomizePatch> d)
+										std::shared_ptr<DerandomizePatch> d,
+										std::shared_ptr<OwnCameraPatch> op)
   : conn(c),
 	irp(i),
 	seeder(s),
@@ -110,7 +111,8 @@ NetplaySession::NetplaySession(int pid, std::shared_ptr<InputPushBuilder> pb_net
 	dp(d),
 	character_synced(false),
 	pid(pid),
-	no_push_counter(0)
+	no_push_counter(0),
+	own_camera(op)
 {
 	{
 		InputFrame empty = {};
@@ -133,10 +135,8 @@ NetplaySession::NetplaySession(int pid, std::shared_ptr<InputPushBuilder> pb_net
 
 	controller = std::make_shared<NetplaySession_Controller>();
     antipause = std::make_shared<AntipausePatch>(gh->spel);
-    own_camera = std::make_shared<OwnCameraPatch>(pid, gh->spel);
 
 	antipause->perform();
-	own_camera->perform();
 
 	conn->on_disconnect([=](NetplayDisconnectEvent) {
 		close(NS_LOST_CONNECTION);
@@ -370,7 +370,10 @@ void NetplaySession::close(NetplaySessionCloseEvent evt)
 		ipb_net->undo();
 		ipb_local->undo();
 		antipause->undo();
-		own_camera->undo();
+
+		if (own_camera)
+			own_camera->undo();
+
 		controller->shutdown = true;
 		aig.reset();
 		irp->undo();

--- a/netplay_session.h
+++ b/netplay_session.h
@@ -13,6 +13,7 @@
 #include "input_recv_patch.h"
 #include "antipause_patch.h"
 #include "save_manager.h"
+#include "own_camera_patch.h"
 
 #define INPUT_BUFFER_MAX_DEFAULT 8
 
@@ -51,6 +52,7 @@ private:
 	std::shared_ptr<GameHooks> gh;
 	std::shared_ptr<AntipausePatch> antipause;
 	std::shared_ptr<DerandomizePatch> dp;
+	std::shared_ptr<OwnCameraPatch> own_camera;
 
 	std::shared_ptr<NetplaySession_Controller> controller;
 	std::function<void(int)> ping_info_cb;

--- a/netplay_session.h
+++ b/netplay_session.h
@@ -88,7 +88,8 @@ public:
 		std::shared_ptr<InputReceivePatch> irp, 
 		std::shared_ptr<Seeder> seeder,
 		std::shared_ptr<GameHooks> hooks,
-		std::shared_ptr<DerandomizePatch> dp);
+        std::shared_ptr<DerandomizePatch> dp,
+        std::shared_ptr<OwnCameraPatch> op);
 
 	void ping_info(std::function<void(int)> cb);
 	bool is_closed();

--- a/own_camera_patch.cpp
+++ b/own_camera_patch.cpp
@@ -1,0 +1,238 @@
+#include "own_camera_patch.h"
+#include "debug.h"
+
+#include <cassert>
+
+#define EXEC_SPACE_ALLOC 512
+
+// The extra instructions are to find the exact piece of code, because only 2 instructions give the wrong result.
+BYTE kill_player[] = {
+    0x2B, 0xC1,                               // SUB  EAX,ECX
+    0x89, 0x44, 0x24, 0x18,                   // MOV  dword ptr [ESP - 60h],EAX
+    0x0F, 0x88, 0xBE, 0x01, 0x00, 0x00,       // JS   doesn't matter
+    0x83, 0xBB, 0x40, 0x01, 0x00, 0x00, 0x00, // CMP  dword ptr [EBX + 140h],0h
+};
+
+std::string kill_player_mask = "xxxxxxxxxxxxxxxxxxx";
+
+BYTE kill_player_patched[] = {
+    0x90, 0x90,                               // NOP NOP
+    0x89, 0x44, 0x24, 0x18,                   // MOV   dword ptr [ESP - 60h],EAX
+    0x0F, 0x88, 0xBE, 0x01, 0x00, 0x00,       // JS    doesn't matter
+    0x83, 0xBB, 0x40, 0x01, 0x00, 0x00, 0x00, // CMP   dword ptr [EBX + 140h],0h
+};
+
+BYTE ghost_spawn_on_start[] = {
+    0x85, 0xC0,                         // TEST  EAX,EAX
+    0x74, 0x09,                         // JZ    to the ghost spawning code
+    0x83, 0xF8, 0x0B,                   // CMP   EAX,Bh
+    0x0F, 0x85, 0xA8, 0x00, 0x00, 0x00, // JNZ   over the ghost spawning code
+};
+
+std::string ghost_spawn_on_start_mask = "xxxxxxxxxxxxx";
+
+BYTE ghost_spawn_on_start_patched[] = {
+    0x90, 0x90, 0x90, 0x90,       // NOP NOP NOP NOP
+    0x90, 0x90, 0x90, 0x90,       // NOP NOP NOP NOP
+    0xE9, 0xA8, 0x00, 0x00, 0x00, // JMP   over the ghost spawning code
+};
+
+BYTE ghost_spawn_on_death[] = {
+    0x83, 0x79, 0x58, 0x17,                   // CMP  dword ptr [ECX + 58h],17h
+    0x75, 0x0C,                               // JNZ  to the ghost spawning code
+    0x8B, 0x41, 0x4C,                         // MOV  EAX,dword ptr [ECX + 4Ch]
+    0x80, 0xB8, 0x81, 0x2D, 0x12, 0x00, 0x00, // CMP  dword ptr [EAX + 122D81h],0h
+    0x74, 0x70,                               // JZ   over the ghost spawning code
+};
+
+std::string ghost_spawn_on_death_mask = "xxxxxxxxxxxxxxxxxx";
+
+BYTE ghost_spawn_on_death_patched[] = {
+    0x90, 0x90, 0x90, 0x90, // NOP NOP NOP NOP
+    0x90, 0x90, 0x90, 0x90, // NOP NOP NOP NOP
+    0x90, 0x90, 0x90, 0x90, // NOP NOP NOP NOP
+    0x90, 0x90, 0x90, 0x90, // NOP NOP NOP NOP
+    0xEB, 0x70,             // JMP over the ghost spawning code
+};
+
+BYTE game_instance_usage[] = {
+    0x8B, 0x2D, 0x00, 0x00, 0x00, 0x00, // MOV   EBP, dword ptr[GAME_INSTANCE_ADDRESS]
+    0xDD, 0xD8,                         // FSTP  ST0
+    0x8B, 0x85, 0x84, 0x06, 0x44, 0x00, // MOV   EAX, dword ptr[EBP + 440684h] = > LAB_00640684
+    0xD9, 0x05, 0x00, 0x00, 0x00, 0x00, // FLD   dword ptr[HUGE_FLOAT_CONSTANT]
+    0x83, 0xCF, 0xFF,                   // OR    EDI, ffffffffh
+};
+
+std::string game_instance_usage_mask = "xx....xxxxxxxxxx....xxx";
+
+size_t game_instance_usage_offset = 2;
+
+BYTE lock_camera_on_flag_owner_1[] = {
+    0x8B, 0x42, 0x30,                         //    MOV   EAX,dword ptr [EDX + 30h]
+    0x3B, 0xC1,                               //    CMP   EAX,ECX
+    0x74, 0x16,                               //    JZ    after_lock_on_flag_owner
+    0x3B, 0xC3,                               //    CMP   EAX,EBX
+    0x74, 0x0F,                               //    JZ    before_lock_on_flag_owner
+    0x83, 0x78, 0x08, 0x03,                   //    CMP   dword ptr [EAX + 8h],3h
+    0x74, 0x0C,                               //    JZ    after_lock_on_flag_owner
+    0x81, 0x78, 0x0C, 0x1F, 0x04, 0x00, 0x00, //    CMP   dword ptr [EAX + CH],41Fh
+    0x74, 0x03,                               //    JZ    after_lock_on_flag_owner
+                                              // before_lock_on_flag_owner:
+    0x89, 0x4A, 0x30,                         //    MOV   dword ptr [EDX + 30h],ECX
+                                              // after_lock_on_flag_owner:
+};
+
+std::string lock_camera_on_flag_owner_1_mask = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+
+BYTE lock_camera_on_flag_owner_1_prepend[] = {
+    0x8B, 0x2D, 0x00, 0x00, 0x00, 0x00, //    MOV   EBP,dword ptr [GAME_INSTANCE_ADDRESS]
+    0x8B, 0x85, 0x00, 0x00, 0x00, 0x00, //    MOV   EAX,dword ptr [EBP + player_offsets[pid]]
+    0x39, 0xD8,                         //    CMP   EAX,EBX
+    0x74, 0x18,                         //    JZ    after_lock_on_desired_player
+    0x39, 0x98, 0x40, 0x01, 0x00, 0x00, //    CMP   dword ptr [EAX + 140h],EBX
+    0x7F, 0x0B,                         //    JG    before_lock_on_desired_player
+    0x8B, 0xA8, 0x80, 0x02, 0x00, 0x00, //    MOV   EBP,dword ptr [EAX + 280h]
+    0x38, 0x5D, 0x7C,                   //    CMP   byte ptr [EBP + 7Ch],BL
+    0x74, 0x05,                         //    JZ    after_lock_on_desired_player
+                                        // before_lock_on_desired_player:
+    0x89, 0x42, 0x30,                   //    MOV   dword ptr [EDX + 30h],EAX
+    0xEB, 0x1D,                         //    JMP   after_lock_on_flag_owner
+                                        // after_lock_on_desired_player:
+};
+
+BYTE lock_camera_on_flag_owner_2[] = {
+    0x8B, 0x41, 0x30,       //    MOV   EAX,dword ptr [ECX + 30h]
+    0x3B, 0xC6,             //    CMP   EAX,ESI
+    0x74, 0x0D,             //    JZ    after_lock_on_flag_owner
+    0x3B, 0xC3,             //    CMP   EAX,EBX
+    0x74, 0x06,             //    JZ    before_lock_on_flag_owner
+    0x83, 0x78, 0x08, 0x03, //    CMP   dword ptr [EAX + 8h],3h
+    0x74, 0x03,             //    JZ    after_lock_on_flag_owner
+                            // before_lock_on_flag_owner:
+    0x89, 0x71, 0x30,       //    MOV   dword ptr [ECX + 30h],ESI
+                            // after_lock_on_flag_owner:
+};
+
+std::string lock_camera_on_flag_owner_2_mask = "xxxxxxxxxxxxxxxxx";
+
+BYTE lock_camera_on_flag_owner_2_prepend[] = {
+    0x8B, 0x2D, 0x00, 0x00, 0x00, 0x00, //    MOV   EBP,dword ptr [GAME_INSTANCE_ADDRESS]
+    0x8B, 0x85, 0x00, 0x00, 0x00, 0x00, //    MOV   EAX,dword ptr [EBP + player_offsets[pid]]
+    0x39, 0xD8,                         //    CMP   EAX,EBX
+    0x74, 0x18,                         //    JZ    after_lock_on_desired_player
+    0x39, 0x98, 0x40, 0x01, 0x00, 0x00, //    CMP   dword ptr [EAX + 140h],EBX
+    0x7F, 0x0B,                         //    JG    before_lock_on_desired_player
+    0x8B, 0xA8, 0x80, 0x02, 0x00, 0x00, //    MOV   EBP,dword ptr [EAX + 280h]
+    0x38, 0x5D, 0x7C,                   //    CMP   byte ptr [EBP + 7Ch],BL
+    0x74, 0x05,                         //    JZ    after_lock_on_desired_player
+                                        // before_lock_on_desired_player:
+    0x89, 0x41, 0x30,                   //    MOV   dword ptr [ECX + 30h],EAX
+    0xEB, 0x14,                         //    JMP   after_lock_on_flag_owner
+                                        // after_lock_on_desired_player:
+};
+
+size_t game_instance_address_offset = 2;
+size_t player_address_offset        = 8;
+
+Address instance_player_offsets[] = {
+    0x00440684,
+    0x00440688,
+};
+
+OwnCameraPatch::OwnCameraPatch(int pid, std::shared_ptr<Spelunky> spel) : Patch(spel),
+        is_valid(false),
+        lock_camera_on_flag_owner_1_data(NULL),
+        lock_camera_on_flag_owner_2_data(NULL) 
+{
+    kill_player_address = spel->find_exec_mem(kill_player, kill_player_mask);
+    if (kill_player_address == 0x0) {
+        DBG_EXPR(std::cout << "[OwnCameraPatch] Failed to find code that kills player outside of camera." << std::endl);
+        return;
+    }
+
+    ghost_spawn_on_start_address = spel->find_exec_mem(ghost_spawn_on_start, ghost_spawn_on_start_mask);
+    if (ghost_spawn_on_start_address == 0x0) {
+        DBG_EXPR(std::cout << "[OwnCameraPatch] Failed to find code that spawns an player ghost on level start." << std::endl);
+        return;
+    }
+
+    ghost_spawn_on_death_address = spel->find_exec_mem(ghost_spawn_on_death, ghost_spawn_on_death_mask);
+    if (ghost_spawn_on_death_address == 0x0) {
+        DBG_EXPR(std::cout << "[OwnCameraPatch] Failed to find code that spawns a player ghost on death." << std::endl);
+        return;
+    }
+
+    game_instance_usage_address = spel->find_exec_mem(game_instance_usage, game_instance_usage_mask);
+    if (game_instance_usage_address == 0x0) {
+        DBG_EXPR(std::cout << "[OwnCameraPatch] Failed to find code that uses a game instance." << std::endl);
+        return;
+    }
+
+    spel->read_mem(game_instance_usage_address + game_instance_usage_offset, &game_instance_address, sizeof(game_instance_address));
+
+    lock_camera_on_flag_owner_1_address = spel->find_exec_mem(lock_camera_on_flag_owner_1, lock_camera_on_flag_owner_1_mask);
+    if (lock_camera_on_flag_owner_1_address == 0x0) {
+        DBG_EXPR(std::cout << "[OwnCameraPatch] Failed to find code that locks camera on flag owner." << std::endl);
+        return;
+    }
+
+    lock_camera_on_flag_owner_2_address = spel->find_exec_mem(lock_camera_on_flag_owner_2, lock_camera_on_flag_owner_2_mask);
+    if (lock_camera_on_flag_owner_2_address == 0x0) {
+        DBG_EXPR(std::cout << "[OwnCameraPatch] Failed to find code that locks camera on flag owner." << std::endl);
+        return;
+    }
+
+    lock_camera_on_flag_owner_1_data = spel->allocate(EXEC_SPACE_ALLOC, true);
+    spel->write_mem(lock_camera_on_flag_owner_1_data, lock_camera_on_flag_owner_1_prepend, sizeof(lock_camera_on_flag_owner_1_prepend));
+    spel->write_mem(lock_camera_on_flag_owner_1_data + game_instance_address_offset, &game_instance_address, sizeof(game_instance_address));
+    spel->write_mem(lock_camera_on_flag_owner_1_data + player_address_offset, &instance_player_offsets[pid], sizeof(instance_player_offsets[pid]));
+    
+    lock_camera_on_flag_owner_2_data = spel->allocate(EXEC_SPACE_ALLOC, true);
+    spel->write_mem(lock_camera_on_flag_owner_2_data, lock_camera_on_flag_owner_2_prepend, sizeof(lock_camera_on_flag_owner_2_prepend));
+    spel->write_mem(lock_camera_on_flag_owner_2_data + game_instance_address_offset, &game_instance_address, sizeof(game_instance_address));
+    spel->write_mem(lock_camera_on_flag_owner_2_data + player_address_offset, &instance_player_offsets[pid], sizeof(instance_player_offsets[pid]));
+
+    is_valid = true;
+}
+
+OwnCameraPatch::~OwnCameraPatch() {
+    if (lock_camera_on_flag_owner_1_data != NULL) {
+        spel->release(lock_camera_on_flag_owner_1_data);
+    }
+
+    if (lock_camera_on_flag_owner_2_data != NULL) {
+        spel->release(lock_camera_on_flag_owner_2_data);
+    }
+}
+
+bool OwnCameraPatch::valid() {
+    return is_valid;
+}
+
+bool OwnCameraPatch::_perform() {
+    assert(is_valid);
+
+    spel->write_mem(kill_player_address, kill_player_patched, sizeof(kill_player_patched));
+    spel->write_mem(ghost_spawn_on_start_address, ghost_spawn_on_start_patched, sizeof(ghost_spawn_on_start_patched));
+    spel->write_mem(ghost_spawn_on_death_address, ghost_spawn_on_death_patched, sizeof(ghost_spawn_on_death_patched));
+    spel->jmp_build(lock_camera_on_flag_owner_1_address, sizeof(lock_camera_on_flag_owner_1), lock_camera_on_flag_owner_1_data, sizeof(lock_camera_on_flag_owner_1_prepend));
+    spel->jmp_build(lock_camera_on_flag_owner_2_address, sizeof(lock_camera_on_flag_owner_2), lock_camera_on_flag_owner_2_data, sizeof(lock_camera_on_flag_owner_2_prepend));
+
+    DBG_EXPR(std::cout << "[OwnCameraPatch] Own camera patch applied." << std::endl);
+
+    return true;
+}
+
+bool OwnCameraPatch::_undo() {
+    assert(is_valid);
+
+    spel->write_mem(kill_player_address, kill_player, sizeof(kill_player));
+    spel->write_mem(ghost_spawn_on_start_address, ghost_spawn_on_start, sizeof(ghost_spawn_on_start));
+    spel->write_mem(ghost_spawn_on_death_address, ghost_spawn_on_death, sizeof(ghost_spawn_on_death));
+    spel->write_mem(lock_camera_on_flag_owner_1_address, lock_camera_on_flag_owner_1, sizeof(lock_camera_on_flag_owner_1));
+    spel->write_mem(lock_camera_on_flag_owner_2_address, lock_camera_on_flag_owner_2, sizeof(lock_camera_on_flag_owner_2));
+
+    DBG_EXPR(std::cout << "[OwnCameraPatch] Own camera patch unapplied." << std::endl);
+
+    return true;
+}

--- a/own_camera_patch.h
+++ b/own_camera_patch.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "patches.h"
+#include "spelunky.h"
+
+class OwnCameraPatch : public Patch {
+private:
+    bool is_valid;
+    Address kill_player_address;
+    Address ghost_spawn_on_start_address;
+    Address ghost_spawn_on_death_address;
+    Address game_instance_usage_address;
+    Address game_instance_address;
+    Address lock_camera_on_flag_owner_1_address;
+    Address lock_camera_on_flag_owner_2_address;
+    Address lock_camera_on_flag_owner_1_data;
+    Address lock_camera_on_flag_owner_2_data;
+
+public:
+    OwnCameraPatch(int pid, std::shared_ptr<Spelunky> spel);
+    ~OwnCameraPatch();
+
+    virtual bool valid() override;
+
+private:
+    virtual bool _perform() override;
+    virtual bool _undo() override;
+};

--- a/static_area_patch.cpp
+++ b/static_area_patch.cpp
@@ -146,6 +146,8 @@ bool StaticAreaPatch::find_jmp() {
 		[=](const std::pair<Address, size_t>& a, const std::pair<Address, size_t>& b) {
 			if(a.second < 5 && b.second >= 5)
 				return true;
+			else if(b.second < 5 && a.second >= 5)
+				return false;
 			else
 				return a.first > b.first;
 		}


### PR DESCRIPTION
Added the ability in netplay to play without camera lock on flag holder (it was very annoying in vanilla game, Frozlunky and Steam Remote Play). It can be enabled via a checkbox in netplay menu. Players out of the screen don't die in this mode by timeout (would break the net sync, both players would see their friends die out of their screens). Player ghosts could add some synchronization issues, so I disabled them too.
Fixed some memory issues.
Made it to compile against vcpkg libraries (for quick install, rather than messing with each library separately).
Removed resource references, because they are not included.
In release build I have rare crashes on startup. Could be some thirdparty from vcpkg, I don't think my code could do that... One time I also encountered players to be out of sync, but that also happened to me quite a few times in vanilla Frozlunky before my patch.
Thank you very much for Frozlunky! It is a lot of fun!